### PR TITLE
:sparkles: card / gaz

### DIFF
--- a/src/engine/cards.js
+++ b/src/engine/cards.js
@@ -16,7 +16,7 @@ export const pick = (store, action) => {
 
   const nextState = store.getState()
   const { type: cardType } = nextState.activeCard
-  if (['shake', 'water', 'gaz'].includes(cardType)) {
+  if (['shake', 'water', 'gaz', 'enemy'].includes(cardType)) {
     store.dispatch(`@cards>${cardType}`)
   } else if (nextState.activeCard.type === 'landslide') {
     store.dispatch(roll.then({ type: '@cards>landslide' }))

--- a/src/engine/cards.spec.js
+++ b/src/engine/cards.spec.js
@@ -96,6 +96,19 @@ describe('cards', () => {
       expect(store.dispatch).toHaveBeenCalledTimes(1)
       expect(store.dispatch).toHaveBeenCalledWith('@cards>gaz')
     })
+
+    it('should calls @cards>enemy if the next card is a enemy card', () => {
+      const store = createStore({
+        deckCards: [{ type: 'enemy' }],
+      })
+
+      store.dispatch = jest.fn()
+
+      cards.pick(store, {})
+
+      expect(store.dispatch).toHaveBeenCalledTimes(1)
+      expect(store.dispatch).toHaveBeenCalledWith('@cards>enemy')
+    })
   })
 
   describe('shake', () => {

--- a/src/engine/listeners.js
+++ b/src/engine/listeners.js
@@ -14,6 +14,7 @@ export default [
   ['@cards>landslide', cards.landslide],
   ['@cards>water', cards.processMarkerCard],
   ['@cards>gaz', cards.processMarkerCard],
+  ['@cards>enemy', cards.processMarkerCard],
   // "random"
   ['@dices>init', dices.init],
   ['@dices>roll', dices.roll],

--- a/src/engine/listeners.spec.js
+++ b/src/engine/listeners.spec.js
@@ -90,6 +90,16 @@ describe('listeners', () => {
     })
   })
 
+  describe('@cards>enemy', () => {
+    it('should call cards.processMarkerCard', () => {
+      const engine = createEngine({})
+
+      engine.dispatch('@cards>enemy')
+
+      expect(cards.processMarkerCard).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('@dices>init', () => {
     it('should call dices.init', () => {
       const engine = createEngine({})

--- a/src/utils/cards.js
+++ b/src/utils/cards.js
@@ -6,8 +6,8 @@ const GazCard2 = { type: 'gaz', damage: 2, duration: 2 }
 const LandslideCard = { type: 'landslide', damage: 3, duration: 1 }
 const LandslideCard2 = { type: 'landslide', damage: 3, duration: 2 }
 const ShakeCard = { type: 'shake', damage: 1, duration: 1 }
-const HorrorCard = { type: 'enemy', damage: 0, duration: 1 }
-const HorrorCard2 = { type: 'enemy', damage: 0, duration: 2 }
+const HorrorCard = { type: 'enemy', damage: 3, duration: 1 }
+const HorrorCard2 = { type: 'enemy', damage: 3, duration: 2 }
 
 const cards = [
   EndCard,


### PR DESCRIPTION
⚠️ this is based on "water" branch

fixes #17 

I created a `processMarkerCard` reaction to process all card that are "marker" like water/gaz/enemy etc

I also fixed some tests that were missing on previous PR.

The idea is to merge this PR into the water one, then squash merge with title ":sparkles: card / gaz & water"